### PR TITLE
docs: fix broken links and examples

### DIFF
--- a/skills/cloud/google-cloud-networking-observability/references/cloud-nat-analysis.md
+++ b/skills/cloud/google-cloud-networking-observability/references/cloud-nat-analysis.md
@@ -28,7 +28,7 @@ jsonPayload.allocation_status="DROPPED"
 
 ### 2. Aggregate Trends ([BigQuery MCP](mcp-usage.md#bigquery-mcp))
 
-**Tool**: `query_sql`
+**Tool**: `execute_sql`
 
 **SQL Pattern**:
 

--- a/skills/cloud/google-cloud-networking-observability/references/mcp-usage.md
+++ b/skills/cloud/google-cloud-networking-observability/references/mcp-usage.md
@@ -24,7 +24,7 @@ data management and analysis.
 2.  Use `list_table_ids` to find the relevant log table.
 3.  Use `get_table_info` to verify field names (for example, `jsonPayload`
     versus `json_payload`).
-4.  Use `execute_sql_readonly` for the final analysis.
+4.  Use `execute_sql` for the final analysis.
 
 ## Cloud Logging MCP
 

--- a/skills/cloud/google-cloud-networking-observability/references/threat-analysis.md
+++ b/skills/cloud/google-cloud-networking-observability/references/threat-analysis.md
@@ -35,7 +35,7 @@ jsonPayload.action="DENY"
 
 ### 2. Aggregate Threat Trends ([BigQuery MCP](mcp-usage.md#bigquery-mcp))
 
-**Tool**: `query_sql`
+**Tool**: `execute_sql`
 
 **SQL Pattern**: **Note**: In BigQuery, the top-level column name is
 `json_payload` (snake_case). However, fields extracted from inside the JSON

--- a/skills/cloud/google-cloud-networking-observability/references/vpc-flow-analysis.md
+++ b/skills/cloud/google-cloud-networking-observability/references/vpc-flow-analysis.md
@@ -17,7 +17,7 @@ high-volume trends. Fallback to the CLI if the MCP tools are not available.
     distributions, or find "top talkers." This usually involves SQL queries to
     summarize data rather than inspecting individual logs.
 
-### 1. View Logs ([Cloud Logging MCP](mcp-usage.md#cloudloggingmcp))
+### 1. View Logs ([Cloud Logging MCP](mcp-usage.md#cloud-logging-mcp))
 
 **Tool**: `list_log_entries`
 
@@ -29,7 +29,7 @@ logName:"projects/{project_id}/logs/networkmanagement.googleapis.com%2Fvpc_flows
 resource.type="gce_subnetwork"
 ```
 
-### 2. Aggregate Trends ([BigQuery MCP](mcp-usage.md#bigquerymcp))
+### 2. Aggregate Trends ([BigQuery MCP](mcp-usage.md#bigquery-mcp))
 
 **Tool**: `execute_sql`
 

--- a/skills/cloud/google-cloud-recipe-onboarding/SKILL.md
+++ b/skills/cloud/google-cloud-recipe-onboarding/SKILL.md
@@ -95,20 +95,24 @@ default](https://docs.cloud.google.com/service-usage/docs/enabled-service#defaul
 
 ### 6. Deploy Your First Resource
 
-Choose a simple entry point based on your needs: -
-**[Cloud Run](https://docs.cloud.google.com/run/docs) (Recommended for Apps):**
-Deploy a containerized "Hello World" app. -
-**[Compute Engine](https://docs.cloud.google.com/compute/docs):** Create a small
-Linux VM (e.g., `e2-micro` which is part of the Always Free tier in certain
-regions). - **[Cloud Storage](https://docs.cloud.google.com/storage/docs):**
-Create a bucket to store files.
+Choose a simple entry point based on your needs:
 
-Example (Cloud Run): 
+-   **[Cloud Run](https://docs.cloud.google.com/run/docs) (Recommended for Apps):**
+    Deploy a containerized "Hello World" app.
+-   **[Compute Engine](https://docs.cloud.google.com/compute/docs):** Create a small
+    Linux VM (e.g., `e2-micro` which is part of the Always Free tier in certain
+    regions).
+-   **[Cloud Storage](https://docs.cloud.google.com/storage/docs):** Create a bucket
+    to store files.
 
-```bash 
-    gcloud run deploy hello-world \
-    --image=gcr.io/cloudrun/hello \ --platform=managed \ --region=us-central1 \
-    --allow-unauthenticated
+Example (Cloud Run):
+
+```bash
+gcloud run deploy hello-world \
+  --image=gcr.io/cloudrun/hello \
+  --platform=managed \
+  --region=us-central1 \
+  --allow-unauthenticated
 ```
 
 This command will output a public URL, that you can reach in a web browser.


### PR DESCRIPTION
﻿This picks up a few verified docs regressions on current `main`.

Changes:
- fix stale `mcp-usage.md` anchor links in `vpc-flow-analysis.md`
- normalize the BigQuery MCP tool name to `execute_sql` across the networking observability references
- repair the malformed multiline `gcloud run deploy` example in the onboarding recipe

Verification:
- ran a local markdown-target check to confirm the updated `mcp-usage.md` anchor targets exist
- confirmed the touched networking observability files no longer mention `query_sql` or `execute_sql_readonly`
- confirmed the onboarding recipe no longer contains the broken `\ --platform=managed` continuation

Closes #33

I realize `CONTRIBUTING.md` says external PRs may not be accepted; sharing this as a ready-to-apply patch in case it helps with the internal sync path.
