### PR TITLE
docs: fix broken Available Skills links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ repo to install.
 
 ## Available Skills
 
-- [**Gemini API in Agent Platform**](./skills/cloud/gemini-api)
-- [**AlloyDB Basics**](./skills/cloud/alloydb-basics)
-- [**BigQuery Basics**](./skills/cloud/bigquery-basics)
-- [**Cloud Run Basics**](./skills/cloud/cloud-run-basics)
-- [**Cloud SQL Basics**](./skills/cloud/cloud-sql-basics)
-- [**Firebase Basics**](./skills/cloud/firebase-basics)
-- [**Kubernetes Engine (GKE) Basics**](./skills/cloud/gke-basics)
-- [**Recipe: Onboarding to Google Cloud**](./skills/cloud/google-cloud-recipe-onboarding)
-- [**Recipe: Authenticating to Google Cloud**](./skills/cloud/google-cloud-recipe-auth)
-- [**Recipe: Google Cloud Network Observability**](./skills/cloud/google-cloud-networking-observability)
-- [**Google Cloud Well-Architected Framework: Security**](./skills/cloud/google-cloud-waf-security)
-- [**Google Cloud Well-Architected Framework: Reliability**](./skills/cloud/google-cloud-waf-reliability)
-- [**Google Cloud Well-Architected Framework: Cost Optimization**](./skills/cloud/google-cloud-waf-cost-optimization)
+- [**Gemini API in Agent Platform**](./skills/cloud/gemini-api/SKILL.md)
+- [**AlloyDB Basics**](./skills/cloud/alloydb-basics/SKILL.md)
+- [**BigQuery Basics**](./skills/cloud/bigquery-basics/SKILL.md)
+- [**Cloud Run Basics**](./skills/cloud/cloud-run-basics/SKILL.md)
+- [**Cloud SQL Basics**](./skills/cloud/cloud-sql-basics/SKILL.md)
+- [**Firebase Basics**](./skills/cloud/firebase-basics/SKILL.md)
+- [**Kubernetes Engine (GKE) Basics**](./skills/cloud/gke-basics/SKILL.md)
+- [**Recipe: Onboarding to Google Cloud**](./skills/cloud/google-cloud-recipe-onboarding/SKILL.md)
+- [**Recipe: Authenticating to Google Cloud**](./skills/cloud/google-cloud-recipe-auth/SKILL.md)
+- [**Recipe: Google Cloud Network Observability**](./skills/cloud/google-cloud-networking-observability/SKILL.md)
+- [**Google Cloud Well-Architected Framework: Security**](./skills/cloud/google-cloud-waf-security/SKILL.md)
+- [**Google Cloud Well-Architected Framework: Reliability**](./skills/cloud/google-cloud-waf-reliability/SKILL.md)
+- [**Google Cloud Well-Architected Framework: Cost Optimization**](./skills/cloud/google-cloud-waf-cost-optimization/SKILL.md)
 
 ## Support
 


### PR DESCRIPTION
## Summary

After the repo restructure (commit 6f0b877), every entry in the **Available Skills** section of the README points to a skill directory. None of those directories contain a `README.md`, so GitHub renders the file listing instead of the skill documentation — which is why all 13 links appear broken (see screenshots in #30).

This PR appends `/SKILL.md` to each of the 13 links so they resolve to the rendered skill doc.

Fixes #30.

## Changes

- `README.md`: 13 link targets updated from `./skills/cloud/<name>` → `./skills/cloud/<name>/SKILL.md`.

## Test plan

- [x] Verified each `SKILL.md` target file exists in the working tree.
- [x] Reviewer: confirm rendered links resolve correctly on GitHub once the PR is open.

