### PR TITLE
fix: correct numbered list in cloud-run-basics prerequisites

### DIFF
--- a/skills/cloud/cloud-run-basics/SKILL.md
+++ b/skills/cloud/cloud-run-basics/SKILL.md
@@ -30,8 +30,8 @@ types:
     gcloud services enable run.googleapis.com cloudbuild.googleapis.com
     ```
 
-1.  If you are under a domain restriction organization policy [restricting](https://docs.cloud.google.com/organization-policy/restrict-domains)
-   unauthenticated invocations for your project, you will need to access your
+2.  If you are under a domain restriction organization policy [restricting](https://docs.cloud.google.com/organization-policy/restrict-domains)
+    unauthenticated invocations for your project, you will need to access your
     deployed service as described under [Testing private
     services](https://docs.cloud.google.com/run/docs/triggering/https-request#testing-private).
 


### PR DESCRIPTION
## Summary
- Fix the second prerequisite item in `cloud-run-basics/SKILL.md` which incorrectly used `1.` instead of `2.`, breaking the ordered list rendering.

## Test plan
- [ ] Verify the rendered markdown shows a properly numbered list (1, 2) instead of (1, 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)