### PR TITLE
fix: remove erroneous recipe- prefix from networking-observability name

### DIFF
--- a/skills/cloud/google-cloud-networking-observability/SKILL.md
+++ b/skills/cloud/google-cloud-networking-observability/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: google-cloud-recipe-networking-observability
+name: google-cloud-networking-observability
 description: >-
   Investigates Google Cloud networking issues by analyzing logs, metrics, and diagnostics. Use when investigating VPC Flow Logs, NAT, firewall, or threat logs, querying latency and throughput metrics, or running Connectivity Tests for path diagnostics.
 ---


### PR DESCRIPTION
## Summary
- Fix the `name` field in the frontmatter of `google-cloud-networking-observability/SKILL.md`
- The name was incorrectly set to `google-cloud-recipe-networking-observability`, including an erroneous `recipe-` prefix
- This skill is not a recipe skill (unlike `google-cloud-recipe-auth` and `google-cloud-recipe-onboarding`), so the name should match the directory: `google-cloud-networking-observability`

## Test plan
- [ ] Verify the frontmatter `name` field now matches the directory name

🤖 Generated with [Claude Code](https://claude.com/claude-code)