### PR TITLE
fix: remove inconsistent extra frontmatter fields from gke-basics

### DIFF
--- a/skills/cloud/gke-basics/SKILL.md
+++ b/skills/cloud/gke-basics/SKILL.md
@@ -1,9 +1,5 @@
 ---
 name: gke-basics
-license: Apache-2.0
-metadata:
-  author: Google Cloud
-  version: "1.0.0"
 description: "Plan, create, and configure production-ready Google Kubernetes Engine (GKE) clusters using the golden path Autopilot configuration. Covers Day-0 checklist, Autopilot vs Standard, networking (private clusters, VPC-native, Gateway API), security (Workload Identity, Secret Manager, RBAC hardening), observability, scaling, cost optimization, and AI/ML inference. WHEN: create GKE cluster, provision GKE environment, design GKE networking, secure GKE, optimize GKE cost, GKE autoscaling, GKE inference, GKE upgrade, GKE observability, GKE multi-tenancy, GKE batch, GKE HPC, GKE compute class."
 ---
 


### PR DESCRIPTION
## Summary
- Remove `license: Apache-2.0` and `metadata` (containing `author` and `version`) from `gke-basics/SKILL.md` frontmatter
- No other skill in the repository uses these extra fields, creating an inconsistency in the frontmatter schema
- The license is already covered by the repository-level `LICENSE` file (Apache 2.0)

## Test plan
- [ ] Verify frontmatter only contains `name` and `description`, consistent with all other skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)