### PR TITLE
fix: repair broken markdown in recipe-onboarding step 6

### DIFF
--- a/skills/cloud/google-cloud-recipe-onboarding/SKILL.md
+++ b/skills/cloud/google-cloud-recipe-onboarding/SKILL.md
@@ -95,19 +95,23 @@ default](https://docs.cloud.google.com/service-usage/docs/enabled-service#defaul
 
 ### 6. Deploy Your First Resource
 
-Choose a simple entry point based on your needs: -
-**[Cloud Run](https://docs.cloud.google.com/run/docs) (Recommended for Apps):**
-Deploy a containerized "Hello World" app. -
-**[Compute Engine](https://docs.cloud.google.com/compute/docs):** Create a small
-Linux VM (e.g., `e2-micro` which is part of the Always Free tier in certain
-regions). - **[Cloud Storage](https://docs.cloud.google.com/storage/docs):**
-Create a bucket to store files.
+Choose a simple entry point based on your needs:
 
-Example (Cloud Run): 
+-   **[Cloud Run](https://docs.cloud.google.com/run/docs) (Recommended for Apps):**
+    Deploy a containerized "Hello World" app.
+-   **[Compute Engine](https://docs.cloud.google.com/compute/docs):** Create a small
+    Linux VM (e.g., `e2-micro` which is part of the Always Free tier in certain
+    regions).
+-   **[Cloud Storage](https://docs.cloud.google.com/storage/docs):** Create a bucket
+    to store files.
 
-```bash 
-    gcloud run deploy hello-world \
-    --image=gcr.io/cloudrun/hello \ --platform=managed \ --region=us-central1 \
+Example (Cloud Run):
+
+```bash
+gcloud run deploy hello-world \
+    --image=gcr.io/cloudrun/hello \
+    --platform=managed \
+    --region=us-central1 \
     --allow-unauthenticated
 ```
 


### PR DESCRIPTION
## Summary
- Fix broken markdown formatting in Step 6 ("Deploy Your First Resource") of `google-cloud-recipe-onboarding/SKILL.md`
- The list items were concatenated on the same lines with dashes instead of proper bullet point formatting
- The code block had trailing whitespace and incorrect indentation that could break rendering
- Properly format the three deployment options as distinct bullet points and fix the code block indentation

## Before
The list rendered as a single concatenated paragraph. The code block had extra spaces and broken line continuations.

## After
Three distinct bullet points for Cloud Run, Compute Engine, and Cloud Storage, with a properly formatted code block.

## Test plan
- [ ] Verify the markdown renders correctly with proper bullet points and code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)