### PR TITLE
fix: correct "multimedia" to "multimodal" in gemini-api description

### DIFF
--- a/skills/cloud/gemini-api/SKILL.md
+++ b/skills/cloud/gemini-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini-api
-description: Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK. Use when the user asks about using Gemini in an enterprise environment or explicitly mentions Vertex AI, Google Cloud, or Agent Platform. Covers SDK usage (Python, JS/TS, Go, Java, C#), capabilities like Live API, tools, multimedia generation, caching, and batch prediction.
+description: Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK. Use when the user asks about using Gemini in an enterprise environment or explicitly mentions Vertex AI, Google Cloud, or Agent Platform. Covers SDK usage (Python, JS/TS, Go, Java, C#), capabilities like Live API, tools, multimodal generation, caching, and batch prediction.
 compatibility: Requires active Google Cloud credentials and Agent Platform API enabled.
 ---
 


### PR DESCRIPTION
## Summary
- Correct the frontmatter description in `gemini-api/SKILL.md` from "multimedia generation" to "multimodal generation"
- The Gemini API's defining capability is **multimodal** processing — handling text, images, audio, and video across multiple modalities
- "Multimedia" refers to content presentation format, while "multimodal" correctly describes the AI model's cross-modality capabilities
- The skill body already correctly uses "Multimodal understanding" in the capabilities list — this fixes the frontmatter to be consistent

## Test plan
- [ ] Verify the description uses "multimodal" consistently with the capabilities listed in the skill body

🤖 Generated with [Claude Code](https://claude.com/claude-code)