### PR TITLE
Add Workload Manager basics skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ repo to install.
 -   [**Cloud SQL Basics**](./skills/cloud/cloud-sql-basics)
 -   [**Firebase Basics**](./skills/cloud/firebase-basics)
 -   [**Kubernetes Engine (GKE) Basics**](./skills/cloud/gke-basics)
+-   [**Workload Manager Basics**](./skills/cloud/workload-manager-basics)
 -   [**Recipe: Onboarding to Google Cloud**](./skills/cloud/google-cloud-recipe-onboarding)
 -   [**Recipe: Authenticating to Google Cloud**](./skills/cloud/google-cloud-recipe-auth)
 -   [**Recipe: Google Cloud Network Observability**](./skills/cloud/google-cloud-networking-observability)

--- a/skills/cloud/workload-manager-basics/SKILL.md
+++ b/skills/cloud/workload-manager-basics/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: workload-manager-basics
+description: >-
+  Manages Google Cloud Workload Manager evaluations, executions, rules, scanned
+  resources, and validation results by using the public client libraries and
+  REST API. Use when you need to inspect workload best-practice rules, create
+  and run evaluations for SAP, SQL Server, or custom workloads, review
+  violations, export results to BigQuery, or automate Workload Manager through
+  the SDK because no service-specific public CLI or MCP server is available.
+---
+
+# Workload Manager Basics
+
+Workload Manager validates enterprise workloads against Google Cloud best
+practices and recommendations. The public SDK surface is centered on
+evaluations: define a resource scope, choose rules, run an execution, then
+inspect results and scanned resources.
+
+## Use This Flow
+
+```mermaid
+flowchart LR
+    Rules["List rules"] --> Eval["Create or update evaluation"]
+    Resources["Project, folder, or org scope"] --> Eval
+    Eval --> Run["Run evaluation"]
+    Run --> Results["Inspect execution results"]
+    Results --> Remediate["Remediate findings"]
+    Results --> Export["Optional BigQuery export"]
+```
+
+## Prerequisites
+
+1. Enable the Workload Manager API:
+
+   ```bash
+   gcloud services enable workloadmanager.googleapis.com --quiet
+   ```
+
+2. Authenticate locally before using client libraries or REST:
+
+   ```bash
+   gcloud auth application-default login
+   gcloud auth login
+   ```
+
+3. Grant the narrowest role needed for the task. Start with
+   `roles/workloadmanager.viewer` for read-only inspection and use
+   `roles/workloadmanager.evaluationAdmin` or
+   `roles/workloadmanager.admin` only when creating, updating, running, or
+   deleting evaluations.
+
+## Quick SDK Example
+
+Use the Python client library for the first working automation path:
+
+```bash
+python3 -m pip install --upgrade google-cloud-workloadmanager
+```
+
+```python
+from google.cloud import workloadmanager_v1
+
+project_id = "PROJECT_ID"
+location = "LOCATION"
+parent = f"projects/{project_id}/locations/{location}"
+
+client = workloadmanager_v1.WorkloadManagerClient()
+
+rules = client.list_rules(
+    request=workloadmanager_v1.ListRulesRequest(
+        parent=parent,
+        evaluation_type=workloadmanager_v1.Evaluation.EvaluationType.SQL_SERVER,
+    )
+)
+
+for rule in rules.rules:
+    print(rule.name, rule.display_name, rule.severity)
+```
+
+## Reference Directory
+
+- [Core Concepts](references/core-concepts.md): Evaluations, rules,
+  executions, results, scanned resources, supported workload types, and API
+  shape.
+
+- [Client Libraries](references/client-library-usage.md): Python and Go SDK
+  examples for listing rules, creating evaluations, running evaluations, and
+  reading findings.
+
+- [REST Usage](references/rest-usage.md): Direct REST examples for the public
+  Workload Manager API and operations polling.
+
+- [Public CLI Status](references/public-cli-status.md): No documented
+  service-specific `gcloud workload-manager` command group; use `gcloud` only
+  for auth, IAM, API enablement, and REST tokens.
+
+- [Public MCP Status](references/public-mcp-status.md): No documented public
+  Workload Manager MCP server; use SDK or REST instead.
+
+- [Setup Prerequisites](references/setup-prerequisites.md): Terraform examples
+  only for adjacent prerequisites such as API enablement, IAM, BigQuery export
+  datasets, and KMS keys. This is not Workload Manager resource management.
+
+- [IAM & Security](references/iam-security.md): Workload Manager roles,
+  least-privilege guidance, service agents, data handling, and CMEK notes.
+
+If product behavior or API fields are not covered here, check the current
+Workload Manager product documentation and client library reference before
+implementing.
+
+## Authoritative References
+
+- [Workload Manager overview](https://docs.cloud.google.com/workload-manager/docs/overview)
+- [Workload Manager REST API](https://docs.cloud.google.com/workload-manager/docs/reference/rest)
+- [Python package](https://pypi.org/project/google-cloud-workloadmanager/)
+- [Workload Manager IAM roles](https://docs.cloud.google.com/iam/docs/roles-permissions/workloadmanager)

--- a/skills/cloud/workload-manager-basics/references/client-library-usage.md
+++ b/skills/cloud/workload-manager-basics/references/client-library-usage.md
@@ -1,0 +1,213 @@
+# Workload Manager Client Libraries
+
+Use client libraries when working with evaluation lifecycle resources. The
+public Python client is currently beta and supports Python 3.9 or later.
+
+## Python Setup
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install --upgrade google-cloud-workloadmanager
+gcloud auth application-default login
+```
+
+## Python: List Rules
+
+```python
+from google.cloud import workloadmanager_v1
+
+project_id = "PROJECT_ID"
+location = "LOCATION"
+parent = f"projects/{project_id}/locations/{location}"
+
+client = workloadmanager_v1.WorkloadManagerClient()
+response = client.list_rules(
+    request=workloadmanager_v1.ListRulesRequest(
+        parent=parent,
+        evaluation_type=workloadmanager_v1.Evaluation.EvaluationType.SQL_SERVER,
+    )
+)
+
+for rule in response.rules:
+    print(rule.name, rule.display_name, rule.severity)
+```
+
+## Python: Create an Evaluation
+
+Fetch valid rule names first, then create the evaluation. Keep the resource
+filter narrow until the workflow is proven.
+
+```python
+from google.cloud import workloadmanager_v1
+
+project_id = "PROJECT_ID"
+location = "LOCATION"
+evaluation_id = "sql-server-prod"
+parent = f"projects/{project_id}/locations/{location}"
+
+client = workloadmanager_v1.WorkloadManagerClient()
+
+rule_response = client.list_rules(
+    request=workloadmanager_v1.ListRulesRequest(
+        parent=parent,
+        evaluation_type=workloadmanager_v1.Evaluation.EvaluationType.SQL_SERVER,
+    )
+)
+rule_names = [rule.name for rule in rule_response.rules]
+
+evaluation = workloadmanager_v1.Evaluation(
+    description="SQL Server production validation",
+    evaluation_type=workloadmanager_v1.Evaluation.EvaluationType.SQL_SERVER,
+    resource_filter=workloadmanager_v1.ResourceFilter(
+        scopes=[f"projects/{project_id}"],
+        inclusion_labels={"env": "prod"},
+    ),
+    rule_names=rule_names,
+    labels={"owner": "platform", "workload": "sql-server"},
+)
+
+operation = client.create_evaluation(
+    request=workloadmanager_v1.CreateEvaluationRequest(
+        parent=parent,
+        evaluation_id=evaluation_id,
+        evaluation=evaluation,
+    )
+)
+created = operation.result(timeout=600)
+print(created.name)
+```
+
+## Python: Run an Evaluation
+
+```python
+import uuid
+
+from google.cloud import workloadmanager_v1
+
+project_id = "PROJECT_ID"
+location = "LOCATION"
+evaluation_id = "sql-server-prod"
+execution_id = "manual-run-001"
+evaluation_name = (
+    f"projects/{project_id}/locations/{location}/evaluations/{evaluation_id}"
+)
+
+client = workloadmanager_v1.WorkloadManagerClient()
+operation = client.run_evaluation(
+    request=workloadmanager_v1.RunEvaluationRequest(
+        name=evaluation_name,
+        execution_id=execution_id,
+        execution=workloadmanager_v1.Execution(
+            labels={"trigger": "manual"},
+        ),
+        request_id=str(uuid.uuid4()),
+    )
+)
+execution = operation.result(timeout=1200)
+print(execution.name, execution.state)
+```
+
+## Python: Read Findings
+
+```python
+from google.cloud import workloadmanager_v1
+
+execution_name = (
+    "projects/PROJECT_ID/locations/LOCATION/evaluations/EVALUATION_ID/"
+    "executions/EXECUTION_ID"
+)
+
+client = workloadmanager_v1.WorkloadManagerClient()
+for result in client.list_execution_results(
+    request=workloadmanager_v1.ListExecutionResultsRequest(
+        parent=execution_name,
+        filter='severity="HIGH"',
+    )
+):
+    print(result.rule, result.severity, result.resource.name)
+    print(result.violation_message)
+    print(result.documentation_url)
+```
+
+## Python: Update an Evaluation Schedule
+
+```python
+from google.cloud import workloadmanager_v1
+from google.protobuf import field_mask_pb2
+
+evaluation_name = (
+    "projects/PROJECT_ID/locations/LOCATION/evaluations/EVALUATION_ID"
+)
+
+client = workloadmanager_v1.WorkloadManagerClient()
+evaluation = client.get_evaluation(name=evaluation_name)
+evaluation.schedule = "0 0 */1 * *"
+
+operation = client.update_evaluation(
+    request=workloadmanager_v1.UpdateEvaluationRequest(
+        evaluation=evaluation,
+        update_mask=field_mask_pb2.FieldMask(paths=["schedule"]),
+    )
+)
+updated = operation.result(timeout=600)
+print(updated.schedule)
+```
+
+## Go Setup
+
+```bash
+go get cloud.google.com/go/workloadmanager/apiv1
+```
+
+## Go: List Evaluations
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	workloadmanager "cloud.google.com/go/workloadmanager/apiv1"
+	workloadmanagerpb "cloud.google.com/go/workloadmanager/apiv1/workloadmanagerpb"
+	"google.golang.org/api/iterator"
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := workloadmanager.NewClient(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	req := &workloadmanagerpb.ListEvaluationsRequest{
+		Parent: "projects/PROJECT_ID/locations/LOCATION",
+	}
+	it := client.ListEvaluations(ctx, req)
+	for {
+		evaluation, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(evaluation.GetName())
+	}
+}
+```
+
+## Practical Guardrails
+
+- Check the current client reference before using resources outside the
+  evaluation lifecycle; some REST resources may not be generated into every
+  client library yet.
+- Treat long-running operations as asynchronous. Always call `operation.result`
+  with a timeout or poll explicitly.
+- Use request objects instead of mixing request objects and flattened keyword
+  arguments in the same call.
+- Store execution result exports in a dedicated BigQuery dataset when using
+  `BigQueryDestination`.

--- a/skills/cloud/workload-manager-basics/references/core-concepts.md
+++ b/skills/cloud/workload-manager-basics/references/core-concepts.md
@@ -1,0 +1,92 @@
+# Workload Manager Core Concepts
+
+Workload Manager provides validation and automation tooling for enterprise
+workloads on Google Cloud. Public documentation describes it as a service for
+automating workload deployment and validating workloads against best practices
+and recommendations.
+
+## Resource Model
+
+```mermaid
+flowchart TD
+    Scope["Scope: project, folder, or organization"] --> Filter["ResourceFilter"]
+    Filter --> Evaluation["Evaluation"]
+    Rules["Rule names or evaluation type"] --> Evaluation
+    Evaluation --> Execution["Execution"]
+    Execution --> RuleResults["Rule execution results"]
+    Execution --> Findings["Execution results"]
+    Execution --> Scanned["Scanned resources"]
+    Findings --> Commands["Remediation commands"]
+    Evaluation --> BQ["Optional BigQuery destination"]
+```
+
+## Main Resources
+
+- **Evaluation**: Configuration that defines what to validate. It includes a
+  resource filter, workload evaluation type, rule names, labels, optional fixed
+  schedule, optional custom rules bucket, optional BigQuery destination, and
+  optional CMEK key.
+- **Rule**: A best-practice check with display name, severity, categories,
+  remediation text, tags, and asset type.
+- **Execution**: A run of an evaluation. Executions expose state, timing,
+  engine, run type, rule results, notices, external data sources, and summary
+  counts.
+- **ExecutionResult**: A finding or remediation result from an execution,
+  including rule, severity, violation message, documentation URL, affected
+  resource, details, and suggested commands.
+- **ScannedResource**: A resource scanned by an execution, optionally filtered
+  by rule.
+
+## Evaluation Types
+
+The public v1 SDK exposes these evaluation types:
+
+- `SAP`: SAP best practices.
+- `SQL_SERVER`: SQL Server best practices.
+- `OTHER`: Custom best practices.
+
+Use `list_rules` with an evaluation type before creating an evaluation. This
+keeps the selected rule names aligned with the workload type and current public
+rule catalog.
+
+## Evaluation Scope
+
+Use `ResourceFilter` to constrain blast radius:
+
+- `scopes`: `projects/{project_id}`, `folders/{folder_id}`, or
+  `organizations/{organization_id}`.
+- `resource_id_patterns`: Regular-expression style resource ID patterns.
+- `inclusion_labels`: Required labels that must be present on included
+  resources.
+- `gce_instance_filter.service_accounts`: Limits Compute Engine instances to
+  selected service accounts.
+
+Prefer the smallest project or label-filtered scope that answers the question.
+Folder or organization scopes need broader permissions and can produce more
+results, more logs, and more BigQuery export data.
+
+## Scheduling
+
+`Evaluation.schedule` accepts fixed cron strings documented in the SDK:
+
+- `0 */1 * * *`: hourly
+- `0 */6 * * *`: every 6 hours
+- `0 */12 * * *`: every 12 hours
+- `0 0 */1 * *`: daily
+- `0 0 */7 * *`: weekly
+- `0 0 */14 * *`: every 14 days
+- `0 0 1 */1 *`: monthly
+
+If a user needs an ad hoc run, use `run_evaluation` instead of adding a
+schedule.
+
+## Public Surface Boundaries
+
+The Python SDK package `google-cloud-workloadmanager` and generated Go client
+cover evaluation workflows: evaluations, executions, execution results, rules,
+and scanned resources.
+
+The REST reference may expose additional resources, such as deployments,
+actuations, discovered profiles, insights, and operations. When a needed
+resource is not available in a client library, use the REST API directly and
+keep the request shape close to the REST reference.

--- a/skills/cloud/workload-manager-basics/references/iam-security.md
+++ b/skills/cloud/workload-manager-basics/references/iam-security.md
@@ -1,0 +1,60 @@
+# Workload Manager IAM and Security
+
+Use least privilege and start read-only. Evaluation creation and runs can scan
+resource metadata across a project, folder, or organization, so scope and role
+choice matter.
+
+## Common Roles
+
+| Role | Use |
+| --- | --- |
+| `roles/workloadmanager.viewer` | Read Workload Manager resources. |
+| `roles/workloadmanager.evaluationViewer` | Read evaluation resources and results. |
+| `roles/workloadmanager.evaluationAdmin` | Create, update, run, and delete evaluations and executions. |
+| `roles/workloadmanager.admin` | Full Workload Manager administration. |
+| `roles/workloadmanager.deploymentViewer` | Read deployment resources exposed by the REST API. |
+| `roles/workloadmanager.deploymentAdmin` | Manage deployment resources exposed by the REST API. |
+| `roles/workloadmanager.insightWriter` | Write or delete Workload Manager insights exposed by the REST API. |
+| `roles/workloadmanager.workloadViewer` | View workload resources and metadata. |
+| `roles/workloadmanager.worker` | Worker execution role for service-managed operations. |
+| `roles/workloadmanager.serviceAgent` | Service agent role; do not grant to humans or general automation identities. |
+
+## Role Selection
+
+- Listing rules, evaluations, executions, results, and scanned resources:
+  `roles/workloadmanager.viewer` or `roles/workloadmanager.evaluationViewer`.
+- Creating or updating evaluations: `roles/workloadmanager.evaluationAdmin`.
+- Running evaluations: `roles/workloadmanager.evaluationAdmin`.
+- Full administration across Workload Manager resources:
+  `roles/workloadmanager.admin`.
+- Folder or organization scope: grant roles at that scope only when project
+  scope cannot answer the request.
+
+## Data Handling
+
+- Results can include resource names, service accounts, labels, observed
+  settings, violation messages, remediation commands, and documentation URLs.
+- BigQuery export datasets should have restricted dataset-level IAM.
+- Logs and SDK debug output can include request metadata. Do not persist debug
+  logs in broad-access locations.
+- Use a dedicated automation service account instead of user credentials for
+  recurring evaluations.
+
+## CMEK
+
+`Evaluation.kms_key` accepts a key in this format:
+
+```text
+projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY
+```
+
+Make sure the Workload Manager service agent has the needed KMS permissions
+before creating a CMEK-backed evaluation.
+
+## Deletion and Idempotency
+
+- Use `request_id` for create, update, run, and delete requests when available.
+- Use `force=true` on evaluation deletion only when child executions should be
+  deleted as part of the same request.
+- Before deleting, list executions and confirm whether any results need to be
+  retained or exported.

--- a/skills/cloud/workload-manager-basics/references/public-cli-status.md
+++ b/skills/cloud/workload-manager-basics/references/public-cli-status.md
@@ -1,0 +1,66 @@
+# Workload Manager Public CLI Status
+
+Public documentation does not currently describe a dedicated
+`gcloud workload-manager` command group. Do not write examples that imply
+Workload Manager evaluations, executions, rules, deployments, or actuations can
+be managed through a service-specific `gcloud` command.
+
+Use `gcloud` only for adjacent Google Cloud setup tasks: project configuration,
+authentication, IAM, service enablement, and access tokens. Use the public SDK
+or REST API for Workload Manager resources.
+
+## Enable the API
+
+```bash
+gcloud services enable workloadmanager.googleapis.com --quiet
+```
+
+## Set Project and Location Defaults
+
+```bash
+gcloud config set project PROJECT_ID
+export PROJECT_ID="$(gcloud config get-value project)"
+export LOCATION="LOCATION"
+```
+
+## Authenticate for Local SDK Usage
+
+```bash
+gcloud auth application-default login
+```
+
+## Authenticate for REST Usage
+
+```bash
+export TOKEN="$(gcloud auth print-access-token)"
+```
+
+## Grant a Workload Manager Role
+
+```bash
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="user:USER_EMAIL" \
+  --role="roles/workloadmanager.evaluationAdmin" \
+  --quiet
+```
+
+Use `roles/workloadmanager.viewer` when read-only access is enough.
+
+## REST Bridge
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  "https://workloadmanager.googleapis.com/v1/projects/PROJECT_ID/locations/LOCATION/evaluations"
+```
+
+## Operational Notes
+
+- Do not invent service-specific CLI commands unless they appear in current
+  public `gcloud` documentation.
+- Do not describe `gcloud` as a Workload Manager management surface.
+- `gcloud services`, `gcloud auth`, `gcloud projects add-iam-policy-binding`,
+  and `gcloud logging` remain useful around the Workload Manager API.
+- Enabling the API has no direct charge by itself. Evaluations can create logs,
+  scan resource metadata, and optionally export detailed results to BigQuery,
+  which can incur normal service charges.

--- a/skills/cloud/workload-manager-basics/references/public-mcp-status.md
+++ b/skills/cloud/workload-manager-basics/references/public-mcp-status.md
@@ -1,0 +1,26 @@
+# Workload Manager Public MCP Status
+
+No public Workload Manager MCP server is currently documented. Do not write
+examples that imply Workload Manager has a public MCP integration.
+
+Use the public SDK or REST API for production workflows.
+
+## Current Recommendation
+
+```mermaid
+flowchart LR
+    Request["User request"] --> Check["Need Workload Manager resource?"]
+    Check --> SDK["Use Python or Go SDK for evaluations"]
+    Check --> REST["Use REST for uncovered resources"]
+    SDK --> Verify["Verify operation and findings"]
+    REST --> Verify
+```
+
+## Safety Rules
+
+- Require a project, location, evaluation ID, and explicit resource scope for
+  mutating operations.
+- Default list operations to read-only roles.
+- Require confirmation before deleting evaluations or executions.
+- Surface BigQuery export destinations and CMEK key names before creating or
+  updating evaluations.

--- a/skills/cloud/workload-manager-basics/references/rest-usage.md
+++ b/skills/cloud/workload-manager-basics/references/rest-usage.md
@@ -1,0 +1,145 @@
+# Workload Manager REST Usage
+
+Use REST when the SDK does not cover a needed resource, when debugging raw
+requests, or when building language-agnostic automation.
+
+## Setup
+
+```bash
+export PROJECT_ID="PROJECT_ID"
+export LOCATION="LOCATION"
+export TOKEN="$(gcloud auth print-access-token)"
+export BASE_URL="https://workloadmanager.googleapis.com/v1"
+```
+
+## List Rules
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${BASE_URL}/projects/${PROJECT_ID}/locations/${LOCATION}/rules"
+```
+
+Filter by evaluation type when selecting rules for a specific workload:
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${BASE_URL}/projects/${PROJECT_ID}/locations/${LOCATION}/rules?evaluationType=SQL_SERVER"
+```
+
+## Create an Evaluation
+
+```bash
+export EVALUATION_ID="sql-server-prod"
+export REQUEST_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+curl -sS -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  "${BASE_URL}/projects/${PROJECT_ID}/locations/${LOCATION}/evaluations?evaluationId=${EVALUATION_ID}&requestId=${REQUEST_ID}" \
+  -d @- <<'JSON'
+{
+  "description": "SQL Server production validation",
+  "evaluationType": "SQL_SERVER",
+  "resourceFilter": {
+    "scopes": ["projects/PROJECT_ID"],
+    "inclusionLabels": {
+      "env": "prod"
+    }
+  },
+  "ruleNames": [
+    "projects/PROJECT_ID/locations/LOCATION/rules/RULE_ID"
+  ],
+  "labels": {
+    "owner": "platform",
+    "workload": "sql-server"
+  }
+}
+JSON
+```
+
+Replace `PROJECT_ID`, `LOCATION`, and `RULE_ID` inside the JSON before running.
+The API returns a long-running operation.
+
+## Poll an Operation
+
+```bash
+export OPERATION_NAME="projects/${PROJECT_ID}/locations/${LOCATION}/operations/OPERATION_ID"
+
+curl -sS \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${BASE_URL}/${OPERATION_NAME}"
+```
+
+The operation response contains `done: true` when complete. If an error is
+present, fix that error before retrying with a new request ID.
+
+## Run an Evaluation
+
+```bash
+export EVALUATION_ID="sql-server-prod"
+export EXECUTION_ID="manual-run-001"
+export REQUEST_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+curl -sS -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  "${BASE_URL}/projects/${PROJECT_ID}/locations/${LOCATION}/evaluations/${EVALUATION_ID}/executions:run" \
+  -d @- <<JSON
+{
+  "executionId": "${EXECUTION_ID}",
+  "execution": {
+    "labels": {
+      "trigger": "manual"
+    }
+  },
+  "requestId": "${REQUEST_ID}"
+}
+JSON
+```
+
+## List Executions
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${BASE_URL}/projects/${PROJECT_ID}/locations/${LOCATION}/evaluations/${EVALUATION_ID}/executions"
+```
+
+## List Execution Results
+
+```bash
+export EXECUTION_ID="EXECUTION_ID"
+
+curl -sS \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${BASE_URL}/projects/${PROJECT_ID}/locations/${LOCATION}/evaluations/${EVALUATION_ID}/executions/${EXECUTION_ID}/results"
+```
+
+## List Scanned Resources
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${BASE_URL}/projects/${PROJECT_ID}/locations/${LOCATION}/evaluations/${EVALUATION_ID}/executions/${EXECUTION_ID}/scannedResources"
+```
+
+## Delete an Evaluation
+
+Use `force=true` only when associated child resources should also be deleted.
+
+```bash
+export REQUEST_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+
+curl -sS -X DELETE \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "${BASE_URL}/projects/${PROJECT_ID}/locations/${LOCATION}/evaluations/${EVALUATION_ID}?requestId=${REQUEST_ID}&force=true"
+```
+
+## REST-Only Resources
+
+If client libraries do not expose a Workload Manager resource yet, consult the
+REST reference for endpoints such as deployments, actuations, discovered
+profiles, insights, and operations. Keep automation defensive because generated
+client libraries and REST resources can land at different times.

--- a/skills/cloud/workload-manager-basics/references/setup-prerequisites.md
+++ b/skills/cloud/workload-manager-basics/references/setup-prerequisites.md
@@ -1,0 +1,83 @@
+# Workload Manager Setup Prerequisites
+
+This file is not Workload Manager infrastructure-as-code support. Public
+Terraform examples here cover only adjacent prerequisites around Workload
+Manager: API enablement, IAM, BigQuery export datasets, and KMS keys.
+
+Do not write examples that imply Terraform can manage Workload Manager
+evaluations, executions, rules, deployments, actuations, or insights unless a
+current provider reference explicitly documents those resources. Manage
+Workload Manager resources through the public SDK or REST API.
+
+## Terraform: Enable API
+
+```terraform
+resource "google_project_service" "workload_manager" {
+  project            = var.project_id
+  service            = "workloadmanager.googleapis.com"
+  disable_on_destroy = false
+}
+```
+
+## Terraform: Grant Evaluation Admin
+
+```terraform
+resource "google_project_iam_member" "workload_manager_evaluation_admin" {
+  project = var.project_id
+  role    = "roles/workloadmanager.evaluationAdmin"
+  member  = "serviceAccount:${google_service_account.automation.email}"
+}
+```
+
+## Terraform: BigQuery Export Dataset
+
+```terraform
+resource "google_bigquery_dataset" "workload_manager_results" {
+  project    = var.project_id
+  dataset_id = "workload_manager_results"
+  location   = "US"
+}
+```
+
+Reference this dataset from the SDK or REST API with
+`Evaluation.big_query_destination.destination_dataset`.
+
+## Terraform: CMEK Prerequisites
+
+```terraform
+resource "google_kms_key_ring" "workload_manager" {
+  project  = var.project_id
+  name     = "workload-manager"
+  location = var.location
+}
+
+resource "google_kms_crypto_key" "evaluations" {
+  name            = "evaluations"
+  key_ring        = google_kms_key_ring.workload_manager.id
+  rotation_period = "7776000s"
+}
+```
+
+Reference the key from the SDK or REST API with `Evaluation.kms_key` in this
+format:
+
+```text
+projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY
+```
+
+## Automation Boundary
+
+```mermaid
+flowchart LR
+    TF["Terraform prerequisites"] --> API["Enable API"]
+    TF --> IAM["Grant IAM roles"]
+    TF --> BQ["Create BigQuery dataset"]
+    TF --> KMS["Create KMS key"]
+    SDK["SDK or REST"] --> Eval["Create and run evaluations"]
+    Eval --> BQ
+    Eval --> KMS
+```
+
+Keep prerequisite setup and evaluation execution separate. Evaluation runs are
+operational actions with long-running operation state, so they fit better in
+controlled SDK or REST automation than in a Terraform plan.


### PR DESCRIPTION
## Summary

- Add a Workload Manager basics skill for public SDK and REST workflows.
- Cover evaluations, executions, rules, execution results, scanned resources, IAM, and setup prerequisites.
- Document current public boundaries for service-specific CLI, MCP, and Terraform-managed Workload Manager resources.

## Validation

- Parsed Python snippets successfully.
- Verified skill reference links point to existing files.
- Checked wording avoids unsupported public-surface claims.
