### PR TITLE
fix(README): correct Gemini Interactions API link to gemini-interacti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ repo to install.
 ## Available Skills
 
 -   [**Gemini API on Agent Platform**](./skills/cloud/gemini-api)
--   [**Gemini Interactions API on Agent Platform**](./skills/cloud/gemini-api)
+-   [**Gemini Interactions API on Agent Platform**](./skills/cloud/gemini-interactions-api)
 -   [**Managed Agents API on Agent Platform**](./skills/cloud/gemini-agents-api)
 -   [**Skill Registry API on Agent Platform**](./skills/cloud/agent-platform-skill-registry)
 -   [**AlloyDB Basics**](./skills/cloud/alloydb-basics)


### PR DESCRIPTION
Here's the PR description you can use:
## Fixes #136

Fixes the broken link for "Gemini Interactions API on Agent Platform" in README.md.

### Problem

Line 23 of `README.md` linked to `./skills/cloud/gemini-api` instead of `./skills/cloud/gemini-interactions-api`. Any user clicking the link would land in the wrong skill — receiving instructions for the stateless `generateContent` API, missing the mandatory SDK version requirement, and missing critical deprecation warnings.

### Fix

Changed the link on line 23 to point to `./skills/cloud/gemini-interactions-api`, which is the correct directory containing the Interactions API skill.