### PR TITLE
fix(cloud): repoint 8 dead cloud.google.com doc links

### DIFF
--- a/skills/cloud/bigtable-basics/SKILL.md
+++ b/skills/cloud/bigtable-basics/SKILL.md
@@ -112,6 +112,6 @@ defined as SQL queries but they must be created using gcloud CLI.
 ## External Resources
 
 *   [Cloud Bigtable Documentation](https://cloud.google.com/bigtable/docs)
-*   [Bigtable SQL Reference](https://cloud.google.com/bigtable/docs/reference/sql)
+*   [Bigtable SQL Reference](https://cloud.google.com/bigtable/docs/googlesql-overview)
 *   [cbt CLI Reference](https://cloud.google.com/bigtable/docs/cbt-reference)
 *   [gcloud bigtable Reference](https://cloud.google.com/sdk/gcloud/reference/bigtable)


### PR DESCRIPTION
Nine link occurrences across six skills return 404 on Google's current docs host. They sit in the "External Resources" / "Resources" sections these skills point an agent at, so an agent following them lands on a 404.

| dead path | replacement |
|---|---|
| `kubernetes-engine/docs/how-to/rollout-sequencing` | `kubernetes-engine/docs/concepts/about-rollout-sequencing` |
| `load-balancing/docs/overview` | `load-balancing/docs/load-balancing-overview` |
| `kubernetes-engine/docs/how-to/secret-manager` ×2 | `secret-manager/docs/secret-manager-managed-csi-component` |
| `binary-authorization/docs/getting-started-gke` | `binary-authorization/docs/setting-up` |
| `kubernetes-engine/docs/concepts/sandbox` | `kubernetes-engine/docs/concepts/sandbox-pods` |
| `kubernetes-engine/docs/how-to/pod-security-standards` | `kubernetes-engine/docs/how-to/podsecurityadmission` |
| `bigtable/docs/reference/sql` | `bigtable/docs/googlesql-overview` |
| `alloydb/docs/reference/` | `alloydb/docs/reference/rest` |

Each replacement was checked for a 200 and for a page title matching the existing link text — e.g. `secret-manager-managed-csi-component` renders as "Use Secret Manager add-on with Google Kubernetes Engine", which covers both the "Secret Manager Add-on for GKE" and "Google Secret Manager CSI Driver" link texts, and `binary-authorization/docs/setting-up` renders as "Set up for GKE". After the change all 89 `cloud.google.com` links under `skills/` resolve.

Only link targets changed; no link text, prose, or code was touched.

Two notes:

- I swept all 837 external URLs under `skills/` and `plugins/`. The only other failures were ~15 `registry.terraform.io` URLs, which are **not** broken — that host returns "Content not available in your region" for every path from my location, including its own root. I left those alone.
- I see CONTRIBUTING says external PRs aren't accepted. Happy to close this and refile as an issue if you prefer — the table above is the whole report, so nothing is lost either way.

## Unrelated finding

`skills/cloud/agent-platform-alert-configuration/scripts/analyze_traffic_test.py` fails for anyone outside Google: it reads mock data from `agent-platform-alert-configuration/_internal`, which is not in the repo, not gitignored, and not a submodule, so all 12 of its cases error with `FileNotFoundError`. The other 13 Python test files pass. I did not touch it because the fix could be either publishing the fixtures or dropping the test, which is your call — happy to file it separately.