### PR TITLE
fix(agent-platform-migrate-from-ai-studio): use numeric-project-id metadata key for in-VM project number

### DIFF
--- a/skills/cloud/agent-platform-migrate-from-ai-studio/SKILL.md
+++ b/skills/cloud/agent-platform-migrate-from-ai-studio/SKILL.md
@@ -264,7 +264,7 @@ echo "Project number: $PROJECT_NUMBER"
 Within a Compute Engine VM, run:
 
 ```bash
-export PROJECT_NUMBER=$(curl "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
+export PROJECT_NUMBER=$(curl "http://metadata.google.internal/computeMetadata/v1/project/numeric-project-id" -H "Metadata-Flavor: Google")
 echo "Project number: $PROJECT_NUMBER"
 ```
 


### PR DESCRIPTION
## What

In `skills/cloud/agent-platform-migrate-from-ai-studio/SKILL.md`, the OpenClaw setup step 3 has two branches that resolve the GCP project number:

- Out-of-VM: `gcloud projects describe "$PROJECT_ID" --format="value(projectNumber)"` — returns the **project number**. Correct.
- In-VM: `curl "http://metadata.google.internal/computeMetadata/v1/project/project-id"` — the `project-id` metadata endpoint returns the **project ID**, not the project number.

The value is then interpolated into the Compute Engine default service account address (`${PROJECT_NUMBER}-compute@developer.gserviceaccount.com`), which requires the numeric project number. With a project ID substituted (e.g. `my-project-123-compute@...`), the address does not resolve and the next step's `gcloud iam service-accounts keys create --iam-account=...` fails.

## Why

This was reported in #207 as a separate defect in the same OpenClaw section. The metadata server serves the project number at `project/numeric-project-id`; switching the in-VM branch to that key makes it consistent with the out-of-VM branch and produces a valid service account address.

## Test

Verification is by inspection of the exact metadata endpoints:

- `project/project-id` -> project ID (string, e.g. `my-project-123`)
- `project/numeric-project-id` -> project number (e.g. `123456789012`)

No other reference to `project/project-id` exists in this repository (code search confirmed the only occurrence is the line being changed).